### PR TITLE
Purchase form updates with out of stock message

### DIFF
--- a/src/FoxyStripeInventoryManagerExtension.php
+++ b/src/FoxyStripeInventoryManagerExtension.php
@@ -5,16 +5,29 @@ namespace Dynamic\FoxyStripe\ORM;
 use Dynamic\FoxyStripe\Page\ProductPage;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\HeaderField;
 
+/**
+ * Class FoxyStripeInventoryManagerExtension
+ * @package Dynamic\FoxyStripe\ORM
+ *
+ * @property ProductPage|\Dynamic\FoxyStripe\ORM\FoxyStripeInventoryManager $owner
+ */
 class FoxyStripeInventoryManagerExtension extends Extension
 {
     /**
-     * @param $form
+     * @param \SilverStripe\Forms\Form $form
      */
     public function updateFoxyStripePurchaseForm(&$form)
     {
-        if (!$this->owner->getIsProductAvailable()) {
-            $form = false;
+        if ($this->owner->Available && !$this->owner->getIsProductAvailable()) {
+            $form->setFields(FieldList::create([
+                HeaderField::create('submitPrice', 'Currently Out of Stock', 4),
+            ]));
+            if ($submit = $form->Actions()->fieldByName('')) {
+                $submit->setAttribute('Disabled', true);
+            }
             return;
         }
 

--- a/src/FoxyStripeInventoryManagerExtension.php
+++ b/src/FoxyStripeInventoryManagerExtension.php
@@ -23,7 +23,7 @@ class FoxyStripeInventoryManagerExtension extends Extension
     {
         if ($this->owner->Available && !$this->owner->getIsProductAvailable()) {
             $form->setFields(FieldList::create([
-                HeaderField::create('submitPrice', 'Currently Out of Stock', 4),
+                HeaderField::create('OutOfStock', 'Currently Out of Stock', 4),
             ]));
             if ($submit = $form->Actions()->fieldByName('')) {
                 $submit->setAttribute('Disabled', true);

--- a/tests/ORM/FoxyStripeInventoryManagerTest.php
+++ b/tests/ORM/FoxyStripeInventoryManagerTest.php
@@ -7,6 +7,8 @@ use Dynamic\FoxyStripe\Test\TestOnly\TestProduct;
 use Dynamic\FoxyStripe\Test\TestOnly\TestProductController;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\HeaderField;
 
 class FoxyStripeInventoryManagerTest extends SapphireTest
 {
@@ -43,6 +45,8 @@ class FoxyStripeInventoryManagerTest extends SapphireTest
     {
         $object = $this->objFromFixture(TestProduct::class, 'one');
         $controller = new TestProductController($object);
-        $this->assertFalse($controller->PurchaseForm());
+        $form = $controller->PurchaseForm();
+        $this->assertInstanceOf(Form::class, $form);
+        $this->assertInstanceOf(HeaderField::class, $form->Fields()->fieldByName('OutOfStock'));
     }
 }


### PR DESCRIPTION
  - no longer returns false
  - disables 'add to cart' button
  - replaces all fields with an out of stock message (unless 'available to purchase' is not checked in cms)