### PR TITLE
Fixes error with products without inventory

### DIFF
--- a/src/Extension/QuantityFieldExtension.php
+++ b/src/Extension/QuantityFieldExtension.php
@@ -15,9 +15,14 @@ class QuantityFieldExtension extends Extension
 
     public function onBeforeRender()
     {
+        if (!$this->owner->getProduct()->hasMethod('getHasInventory')) {
+            return;
+        }
+
         if (!$this->owner->getProduct()->getHasInventory()) {
             return;
         }
+
         $this->owner->setAttribute(
             'data-limit',
             $this->owner->getProduct()->getNumberAvailable()
@@ -30,6 +35,10 @@ class QuantityFieldExtension extends Extension
      */
     public function updateQuantity(&$quantity)
     {
+        if (!$this->owner->getProduct()->hasMethod('getHasInventory')) {
+            return;
+        }
+
         if (!$this->owner->getProduct()->getHasInventory()) {
             return;
         }


### PR DESCRIPTION
  - check if the product has `getHasInventory` before doing anything