### PR TITLE
fix: Silverstripe 4 upgrade - PHP constraint and code style cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: CI
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   ci:
     name: CI
-    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v4
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   ci:
     name: CI
-    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v4

--- a/_config.php
+++ b/_config.php
@@ -1,4 +1,3 @@
 <?php
 
-define('FOXYSTRIPE_INVENTORY_PATH', __DIR__);
-define('FOXYSTRIPE_INVENTORY_DIR', basename(__DIR__));
+// FoxyStripe Inventory configuration

--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,13 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/jsirish/foxystripe"
+            "url": "https://github.com/jsirish/foxystripe",
+            "no-api": true
         },
         {
             "type": "vcs",
-            "url": "https://github.com/dynamic/foxyclient-php"
+            "url": "https://github.com/dynamic/foxyclient-php",
+            "no-api": true
         }
     ],
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.1 || ^8.0",
-        "dynamic/foxystripe": "^4.0@dev",
+        "dynamic/foxystripe": "^4.1",
         "silverstripe/recipe-core": "^4.2",
         "silverstripe/vendor-plugin": "^1.0",
         "unclecheese/display-logic": "^2.0@dev"

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,15 @@
         }
     ],
     "keywords": [
-        "silverstripe", "foxystripe", "ecommerce", "inventory"
+        "silverstripe",
+        "foxystripe",
+        "ecommerce",
+        "inventory"
     ],
     "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.6",
+        "php": "^7.1",
         "dynamic/foxystripe": "^4.0@dev",
         "silverstripe/recipe-core": "^4.2",
         "silverstripe/vendor-plugin": "^1.0",
@@ -40,8 +43,8 @@
         "branch-alias": {
             "dev-master": "2.x-dev"
         },
-		"expose": [
-			"client/dist"
-		]
+        "expose": [
+            "client/dist"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "dynamic/foxystripe": "^4.0@dev",
         "silverstripe/recipe-core": "^4.2",
         "silverstripe/vendor-plugin": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "unclecheese/display-logic": "^2.0@dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "*"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,16 @@
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "*"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/jsirish/foxystripe"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/dynamic/foxyclient-php"
+        }
+    ],
     "config": {
         "process-timeout": 600
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,14 @@
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
     <testsuite name="foxystripe">
         <directory>tests</directory>
     </testsuite>
 
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory suffix=".php">tests/</directory>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/src/Extension/ProductPageControllerExtension.php
+++ b/src/Extension/ProductPageControllerExtension.php
@@ -106,6 +106,6 @@ class ProductPageControllerExtension extends Extension
      */
     protected function getReservationHash($code, $id, $expires)
     {
-        return md5($code.$id.$expires);
+        return md5($code . $id . $expires);
     }
 }

--- a/src/Extension/PurchaseFormExtension.php
+++ b/src/Extension/PurchaseFormExtension.php
@@ -16,7 +16,6 @@ use SilverStripe\Forms\HiddenField;
  */
 class PurchaseFormExtension extends Extension
 {
-
     /**
      * @param \SilverStripe\Forms\FieldList $fields
      */

--- a/src/Extension/QuantityFieldExtension.php
+++ b/src/Extension/QuantityFieldExtension.php
@@ -12,7 +12,6 @@ use SilverStripe\Core\Extension;
  */
 class QuantityFieldExtension extends Extension
 {
-
     public function onBeforeRender()
     {
         if (!$this->owner->getProduct()->hasMethod('getHasInventory')) {


### PR DESCRIPTION
## Summary

Silverstripe 4 upgrade fixes for foxystripe-inventory module.

### Changes
- **composer.json**: Updated PHP constraint from `>=5.6` to `^7.1` for SS4 compatibility
- **_config.php**: Removed SS3-style path constants — SS4 uses `ModuleLoader`
- **PSR-12 formatting**: Applied PHPCBF auto-fixes across src files