### PR TITLE
feat: Silverstripe 5 upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,4 @@ on:
 jobs:
   ci:
     name: CI
-    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v2
-
+    uses: dynamic/silverstripe-ci/.github/workflows/ci.yml@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,5 @@ on:
 jobs:
   ci:
     name: CI
-    uses: dynamic/silverstripe-ci/.github/workflows/ci.yml@v4
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v2
+

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,18 @@
             "Dynamic\\FoxyStripe\\Test\\": "tests/"
         }
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/dynamic/foxystripe",
+            "no-api": true
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/dynamic/foxyclient-php",
+            "no-api": true
+        }
+    ],
     "extra": {
         "installer-name": "foxystripe-inventory",
         "expose": [

--- a/composer.json
+++ b/composer.json
@@ -17,23 +17,15 @@
     "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.1 || ^8.0",
-        "dynamic/foxystripe": "^4.0",
-        "silverstripe/recipe-core": "^4.2",
-        "silverstripe/vendor-plugin": "^1.0",
-        "unclecheese/display-logic": "^2.0@dev"
+        "php": "^8.1",
+        "dynamic/foxystripe": "^5.0",
+        "silverstripe/recipe-core": "^5.0",
+        "unclecheese/display-logic": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "*"
+        "phpunit/phpunit": "^9.6",
+        "squizlabs/php_codesniffer": "^3.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/dynamic/foxyclient-php",
-            "no-api": true
-        }
-    ],
     "config": {
         "process-timeout": 600
     },
@@ -43,8 +35,6 @@
             "Dynamic\\FoxyStripe\\Test\\": "tests/"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "extra": {
         "installer-name": "foxystripe-inventory",
         "expose": [

--- a/src/ORM/FoxyStripeInventoryManager.php
+++ b/src/ORM/FoxyStripeInventoryManager.php
@@ -7,9 +7,8 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\ReadonlyField;
-use SilverStripe\ORM\DataExtension;
-use SilverStripe\Forms\DropdownField;
 use SilverStripe\Core\Extension;
+use SilverStripe\Forms\DropdownField;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
 
 /**
@@ -22,7 +21,7 @@ use UncleCheese\DisplayLogic\Forms\Wrapper;
  *
  * @property-read \Dynamic\FoxyStripe\Page\ProductPage|\Dynamic\FoxyStripe\ORM\FoxyStripeInventoryManager $owner
  */
-class FoxyStripeInventoryManager extends DataExtension
+class FoxyStripeInventoryManager extends Extension
 {
     /**
      * @var array
@@ -46,18 +45,18 @@ class FoxyStripeInventoryManager extends DataExtension
 
         $fields->addFieldsToTab('Root.Inventory', array(
             CheckboxField::create('ControlInventory', 'Control Inventory?')
-                ->setDescription('limit the number of this product available for purchase'),
+            ->setDescription('limit the number of this product available for purchase'),
             Wrapper::create(
-                NumericField::create('PurchaseLimit')
-                    ->setTitle('Number Available')
-                    ->setDescription('add to cart form will be disabled once number available equals purchased'),
-                ReadonlyField::create('NumberPurchased', 'Purchased', $this->getNumberPurchased())//,
-                /*
-                NumericField::create('EmbargoLimit')
-                ->setTitle('Embargo Time')
-                ->setDescription('time in seconds to reserve an item once added to cart')
-                */
-            )->displayIf('ControlInventory')->isChecked()->end(),
+            NumericField::create('PurchaseLimit')
+            ->setTitle('Number Available')
+            ->setDescription('add to cart form will be disabled once number available equals purchased'),
+            ReadonlyField::create('NumberPurchased', 'Purchased', $this->getNumberPurchased()) //,
+            /*
+     NumericField::create('EmbargoLimit')
+     ->setTitle('Embargo Time')
+     ->setDescription('time in seconds to reserve an item once added to cart')
+     */
+        )->displayIf('ControlInventory')->isChecked()->end(),
         ));
     }
 

--- a/src/ORM/FoxyStripeOptionInventoryManager.php
+++ b/src/ORM/FoxyStripeOptionInventoryManager.php
@@ -7,7 +7,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\ReadonlyField;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
 
 /**
@@ -19,7 +19,7 @@ use UncleCheese\DisplayLogic\Forms\Wrapper;
  *
  * @property-read \Dynamic\FoxyStripe\Model\OptionItem $owner
  */
-class FoxyStripeOptionInventoryManager extends DataExtension
+class FoxyStripeOptionInventoryManager extends Extension
 {
     /**
      * @var array
@@ -42,13 +42,13 @@ class FoxyStripeOptionInventoryManager extends DataExtension
 
         $fields->addFieldsToTab('Root.Inventory', array(
             CheckboxField::create('ControlInventory', 'Control Inventory?')
-                ->setDescription('limit the number of this product available for purchase'),
+            ->setDescription('limit the number of this product available for purchase'),
             Wrapper::create(
-                NumericField::create('PurchaseLimit')
-                    ->setTitle('Number Available')
-                    ->setDescription('add to cart form will be disabled once number available equals purchased'),
-                ReadonlyField::create('NumberPurchased', 'Purchased', $this->getNumberPurchased())//,
-            )->displayIf('ControlInventory')->isChecked()->end(),
+            NumericField::create('PurchaseLimit')
+            ->setTitle('Number Available')
+            ->setDescription('add to cart form will be disabled once number available equals purchased'),
+            ReadonlyField::create('NumberPurchased', 'Purchased', $this->getNumberPurchased()) //,
+        )->displayIf('ControlInventory')->isChecked()->end(),
         ));
     }
 

--- a/src/ORM/ProductPageDataExtension.php
+++ b/src/ORM/ProductPageDataExtension.php
@@ -9,14 +9,14 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordViewer;
 use SilverStripe\Forms\NumericField;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\ORM\ValidationResult;
 
 /**
  * Class ProductPageDataExtension
  * @package Dynamic\Sheeps\ProductCartExpiry\ORM
  */
-class ProductPageDataExtension extends DataExtension
+class ProductPageDataExtension extends Extension
 {
     /**
      * @var array
@@ -40,10 +40,10 @@ class ProductPageDataExtension extends DataExtension
     {
         $expirationFields = [
             CheckboxField::create('CartExpiration')
-                ->setTitle('Cart Product Expiration'),
+            ->setTitle('Cart Product Expiration'),
             $duration = NumericField::create('ExpirationMinutes')
-                ->setTitle('Expiration In Minutes')
-                ->setDescription("After the time listed above in minutes, this product will be removed from the user's cart"),
+            ->setTitle('Expiration In Minutes')
+            ->setDescription("After the time listed above in minutes, this product will be removed from the user's cart"),
         ];
 
         $duration->displayIf('CartExpiration')->isChecked()->end();
@@ -53,8 +53,8 @@ class ProductPageDataExtension extends DataExtension
                 'CartReservations',
                 'Cart Reservations',
                 $this->owner->CartReservations()
-                    ->filter('Expires:GreaterThan', date('Y-m-d H:i:s', strtotime('now')))
-                    ->sort('Created'),
+                ->filter('Expires:GreaterThan', date('Y-m-d H:i:s', strtotime('now')))
+                ->sort('Created'),
                 $cartResConfig = GridFieldConfig_RecordViewer::create()
             );
             $expirationGrid->displayIf('CartExpiration')->isChecked()->end();
@@ -76,9 +76,9 @@ class ProductPageDataExtension extends DataExtension
         if ($this->owner->CartExpiration && $this->owner->ExpirationMinutes < 1) {
             $validationResult
                 ->addFieldError(
-                    'ExpirationMinutes',
-                    'You must set the "Expiration In Minutes" or disable "Cart Product Expiration"'
-                );
+                'ExpirationMinutes',
+                'You must set the "Expiration In Minutes" or disable "Cart Product Expiration"'
+            );
         }
     }
 }


### PR DESCRIPTION
## Silverstripe 5 Upgrade

Minimal-change upgrade from SS4 to SS5 for the inventory add-on.

### Changes

**Dependencies (`composer.json`):**
- PHP `^8.1`, `dynamic/foxystripe` `^5.0`, `silverstripe/recipe-core` `^5.0`
- `unclecheese/display-logic` `^3.0`
- Removed `silverstripe/vendor-plugin` (bundled in SS5)
- Removed VCS repository entry for foxyclient
- Removed `minimum-stability: dev`

**CI:**
- Updated to `dynamic/silverstripe-ci/.github/workflows/ci.yml@v4`

**SS5 Breaking Changes:**
- `DataExtension` → `Extension` in 3 files (`FoxyStripeInventoryManager`, `FoxyStripeOptionInventoryManager`, `ProductPageDataExtension`)
- Removed duplicate `Extension` import in `FoxyStripeInventoryManager`

### Notes
- `PurchaseFormExtension` already used `Extension` (not `DataExtension`) — no change needed
- `insertBefore` call in `PurchaseFormExtension` already uses correct SS5 parameter order
- Depends on `dynamic/foxystripe` `^5.0` (PR #416)